### PR TITLE
Change the default Icinga db name

### DIFF
--- a/icinga2-ansible-web2-ui/defaults/main.yml
+++ b/icinga2-ansible-web2-ui/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for icinga2-ansible-web2-ui
 
-icinga2_db: "icinga"
+icinga2_db: "icinga2"
 icinga2_db_pass: "icinga"
 icinga2_db_user: "icinga"
 icinga2_web_mysql_schema_rh: "/usr/share/icinga2-ido-mysql/schema/mysql.sql"


### PR DESCRIPTION
The Debian package creates a database named "icinga2" by default, and we don't override those defaults in the role.
It seems to make sense, so we can just as well change the role's default to match the package.
Otherwise, on Debian the role will by default generate 2 databases : "icinga" created by the role and "icinga2" created by the package